### PR TITLE
chore: release v1.0.0

### DIFF
--- a/.changeset/six-cups-know.md
+++ b/.changeset/six-cups-know.md
@@ -1,0 +1,7 @@
+---
+"@connectivity-js/core": major
+"@connectivity-js/react": major
+"@connectivity-js/devtools": major
+---
+
+Release v1.0.0 — promote stable API (no behavior changes).


### PR DESCRIPTION
Bumps `core`, `react`, and `devtools` to 1.0.0. The API has stabilized through real-world usage — graduating from 0.x. No behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

